### PR TITLE
make use of user-defined networks to isolate test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ services:
   - docker
 
 env:
+  global:
+    - DOCKER_VERSION=1.10.0-0~trusty
   matrix:
     - TOXENV=py27-ansible20
     - TOXENV=py27-ansibledevel
@@ -16,6 +18,18 @@ matrix:
   allow_failures:
     env: TOXENV=py27-ansibledevel
   fast_finish: true
+
+before_install:
+  # ensure apt-get cache is up-to-date
+  - sudo apt-get -qq update
+
+  # list docker-engine versions
+  - apt-cache madison docker-engine
+
+  # upgrade docker-engine to specific version
+  - export DEBIAN_FRONTEND=noninteractive
+  - sudo apt-get -qq -o Dpkg::Options::="--force-confnew" -y install docker-engine=${DOCKER_VERSION}
+  - docker version
 
 install:
   - pip install codecov tox

--- a/docs/source/feature/integration.rst
+++ b/docs/source/feature/integration.rst
@@ -11,12 +11,22 @@ to open source projects at no cost.
 
    ## .travis.yml
    sudo: required
+   dist: trusty
 
    language: python
    python: 2.7
 
    services:
      - docker
+
+   before_install:
+     # ensure apt-get cache is up-to-date
+     - sudo apt-get -qq update
+
+     # upgrade docker-engine to latest version
+     - export DEBIAN_FRONTEND=noninteractive
+     - sudo apt-get -qq -o Dpkg::Options::="--force-confnew" -y install docker-engine
+     - docker version
 
    install:
      - pip install goodplay

--- a/docs/source/user/install.rst
+++ b/docs/source/user/install.rst
@@ -18,10 +18,13 @@ for running your tests.
    test environment you manage on your own, you can skip Docker installation
    and continue with the next section.
 
+As goodplay makes use of user-defined networks and Docker's embedded DNS
+server to allow hosts to resolve each other, it requires at least Docker
+version ``1.10.0``.
 There are a lot of options when it comes to setting up a Docker host.
 
-When running Linux with a recent kernel version, ``docker`` is most likely
-supported natively.
+When running a Linux distribution with a recent kernel version, ``docker``
+is most likely supported natively.
 In this case the `installation process`_ will finish in a minute.
 
 When running on Mac OS X, ``docker`` is not natively supported.


### PR DESCRIPTION
This also allows us to use docker's embedded DNS server, so hosts are now resolvable (via full-qualified hostname and search domain).