### PR TITLE
support use of local roles

### DIFF
--- a/docs/source/feature/cmdline.rst
+++ b/docs/source/feature/cmdline.rst
@@ -1,0 +1,30 @@
+Command-Line Options
+====================
+
+Additionally to the default ``py.test`` command-line options,
+goodplay provides the following options for ``goodplay`` and ``py.test`` executables.
+
+
+``--use-local-roles``
+---------------------
+
+By default goodplay creates a temporary directory for installing dependent
+roles and ensures that has highest precedence when resolving Ansible roles.
+This is done to ensure your test run doesn't interfere with other roles in
+your `Ansible roles path`_.
+
+There might be cases where you want to disable this default behavior, and
+give the configured `Ansible roles path`_ highest precedence, e.g.:
+
+#. When you're developing multiple Ansible roles at once and you want to
+   test-run them together.
+
+#. When you cannot use Ansible Galaxy's dependency resolution due to Ansible
+   roles being stored in a non-supported location, e.g. non-supported
+   version control system.
+
+When running with ``--use-local-roles`` switch, please ensure you have either
+``ANSIBLE_ROLES_PATH`` environment variable set, or ``roles_path`` configured
+in your ``ansible.cfg``.
+
+.. _`Ansible roles path`: http://docs.ansible.com/ansible/intro_configuration.html#roles-path

--- a/docs/source/feature/test-playbook.rst
+++ b/docs/source/feature/test-playbook.rst
@@ -177,8 +177,8 @@ subdirectories named by convention:
      templates/
      vars/
 
-When writing tests for your role, goodplay expects another conventional
-subdirectory:
+When writing tests for your role, goodplay expects another subdirectory
+by convention:
 
 .. code-block:: none
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ So if you're trying to use a specific feature you should find all the details he
    feature/test-playbook
    feature/dependencies
    feature/config
+   feature/cmdline
    feature/integration
 
 

--- a/goodplay/context.py
+++ b/goodplay/context.py
@@ -9,8 +9,9 @@ from goodplay.config import get_goodplay_config
 
 
 class GoodplayContext(object):
-    def __init__(self, playbook_path):
+    def __init__(self, playbook_path, pytestconfig=None):
         self.playbook_path = playbook_path
+        self.pytestconfig = pytestconfig
 
         self._temp_paths = []
 
@@ -108,8 +109,20 @@ class GoodplayContext(object):
         return yaml.safe_load(self.role_path.join('meta', 'main.yml').read())
 
     @cached_property
+    def role_under_test_roles_path(self):
+        role_under_test_roles_path = self._create_temporary_dir()
+
+        role_under_test_roles_path.join(self.role_path.basename).mksymlinkto(self.role_path)
+
+        return role_under_test_roles_path
+
+    @cached_property
     def installed_roles_path(self):
         return self._create_temporary_dir()
+
+    @cached_property
+    def use_local_roles(self):
+        return self.pytestconfig.getoption('use_local_roles')
 
     def release(self):
         for temp_path in reversed(self._temp_paths):

--- a/goodplay/plugin.py
+++ b/goodplay/plugin.py
@@ -28,6 +28,13 @@ def enable_logging_goodplay_info_to_stdout():
 enable_logging_goodplay_info_to_stdout()
 
 
+def pytest_addoption(parser):
+    parser.addini('use_local_roles', default=False, help='default value for use_local_roles')
+    parser.getgroup('goodplay').addoption(
+        '--use-local-roles', dest='use_local_roles', action='store_true',
+        help='prefer to use local roles instead of auto-installed requirements')
+
+
 # - GoodplayPlaybookFile (pytest.File)
 #   - GoodplayPlatform (pytest.Collector) -- manage docker
 #     - GoodplayPlaybook (pytest.Collector) -- manage ansible runner
@@ -54,7 +61,7 @@ class GoodplayPlaybookFile(pytest.File):
     @classmethod
     def consider_and_create(cls, path, parent):
         if ansible_support.is_test_playbook_file(path):
-            ctx = GoodplayContext(playbook_path=path)
+            ctx = GoodplayContext(playbook_path=path, pytestconfig=parent.config)
 
             if ctx.inventory_path:
                 return GoodplayPlaybookFile(ctx, path, parent)


### PR DESCRIPTION
By default goodplay creates a temporary directory for installing dependent
roles and ensures that has highest precedence when resolving Ansible roles.
This is done to ensure your test run doesn't interfere with other roles in
your Ansible roles path.

There might be cases where you want to disable this default behavior, and
give the configured Ansible roles path highest precedence, e.g.:

#. When you're developing multiple Ansible roles at once and you want to
   test-run them together.

#. When you cannot use Ansible Galaxy's dependency resolution due to Ansible
   roles being stored in a non-supported location, e.g. non-supported
   version control system.

When running with ``--use-local-roles`` switch, please ensure you have either
``ANSIBLE_ROLES_PATH`` environment variable set, or ``roles_path`` configured
in your ``ansible.cfg``.