### PR TITLE
Fix discrepancies in docker-py version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,7 +10,7 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Eric Van Steenbergen <vs.eric@gmail.com>
 
 
 Credits

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.0.0.2
 cached-property==1.3.0
-docker-py==1.7.1
+docker-py==1.7.0
 pytest==2.8.7
 sarge==0.1.4


### PR DESCRIPTION
In setup.py the docker-py version is pinned to <=1.7.0 but in
requirements.txt it is pinned to ==1.7.1. I tried first to put
both at 1.7.1 but that gave me the know error with regards to
https://github.com/docker/docker-py/issues/963. After setting
the docker-py==1.7.0 in requirement.txt make was run without errors.