### PR TITLE
add missing ``ansible_user`` inventory variable in tests

### DIFF
--- a/docs/source/feature/config.rst
+++ b/docs/source/feature/config.rst
@@ -20,8 +20,7 @@ images:
 
 .. code-block:: yaml
 
-   # .goodplay.yml
-   ---
+   ## .goodplay.yml
    platforms:
      - name: EL
        version: 6

--- a/docs/source/feature/integration.rst
+++ b/docs/source/feature/integration.rst
@@ -9,7 +9,7 @@ to open source projects at no cost.
 
 .. code-block:: yaml
 
-   # .travis.yml
+   ## .travis.yml
    sudo: required
 
    language: python

--- a/docs/source/feature/inventory.rst
+++ b/docs/source/feature/inventory.rst
@@ -9,19 +9,23 @@ Throughout this documentation we will often refer to this as *inventory*.
 
 goodplay borrows this term from Ansible which already provides
 `various ways to define inventories`_.
-When doing a test run, goodplay reads an inventory during setup phase and
-creates appropriate hosts as Docker containers.
+When doing a test run, goodplay reads an inventory during setup phase that
+defines the hosts to be used for the test.
+These can be hosts you have already available in your environment or Docker
+containers that are automatically created as we will see in a minute.
 
 The usual and easiest way to define an *inventory* is to create a file
 named ``inventory`` right beside the :ref:`test playbook <writing-test-playbook>`:
 
 .. code-block:: yaml
 
-   # inventory
-   web
-   db
+   ## inventory
+   web ansible_user=root
+   db ansible_user=root
 
 This example defines two hosts -- ``web`` and ``db``.
+The remote user that is used to connect to the host needs to be specified
+via ``ansible_user`` inventory variable.
 
 .. _`various ways to define inventories`: https://docs.ansible.com/ansible/intro_inventory.html
 
@@ -47,9 +51,9 @@ run latest CentOS 7, we could update the inventory file:
 
 .. code-block:: yaml
 
-   # inventory
-   web goodplay_image=centos:centos6
-   db goodplay_image=centos:centos7
+   ## inventory
+   web goodplay_image=centos:centos6 ansible_user=root
+   db goodplay_image=centos:centos7 ansible_user=root
 
 
 .. _`parametrizing-platform`:

--- a/docs/source/feature/test-playbook.rst
+++ b/docs/source/feature/test-playbook.rst
@@ -22,8 +22,7 @@ A pseudo *playbook* -- written as a YAML_ file -- may look like this:
 
 .. code-block:: yaml
 
-   # playbook_name.yml
-   ---
+   ## playbook_name.yml
    # play #1
    - hosts: host1:host2
      tasks:
@@ -93,14 +92,13 @@ An example test playbook that verifies that two hosts
 
 .. code-block:: yaml
 
-   # inventory
-   host1 goodplay_image=centos:centos6
-   host2 goodplay_image=centos:centos6
+   ## inventory
+   host1 goodplay_image=centos:centos6 ansible_user=root
+   host2 goodplay_image=centos:centos6 ansible_user=root
 
 .. code-block:: yaml
 
-   # test_ping_hosts.yml
-   ---
+   ## test_ping_hosts.yml
    - hosts: host1:host2
      tasks:
        - name: hosts are reachable
@@ -121,8 +119,7 @@ Ansible's assert module:
 
 .. code-block:: yaml
 
-   # install_myapp.yml
-   ---
+   ## install_myapp.yml
    - hosts: myapp-hosts
      tasks:
        - name: install myapp
@@ -131,15 +128,14 @@ Ansible's assert module:
 
 .. code-block:: yaml
 
-   # tests/inventory
+   ## tests/inventory
    [myapp-hosts]
-   host1 goodplay_image=centos:centos6
-   host2 goodplay_image=centos:centos6
+   host1 goodplay_image=centos:centos6 ansible_user=root
+   host2 goodplay_image=centos:centos6 ansible_user=root
 
 .. code-block:: yaml
 
-   # tests/test_myapp.yml
-   ---
+   ## tests/test_myapp.yml
    - include: ../install_myapp.yml
 
    - hosts: myapp-hosts

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -11,8 +11,7 @@ that is responsible for installing a plain nginx web server on Ubuntu_:
 
 .. code-block:: yaml
 
-   # nginx_install.yml
-   ---
+   ## nginx_install.yml
    - hosts: web
      tasks:
        - name: install nginx package
@@ -73,8 +72,8 @@ Ubuntu Trusty:
 
 .. code-block:: yaml
 
-   # tests/inventory
-   web goodplay_image=ubuntu-upstart:trusty
+   ## tests/inventory
+   web goodplay_image=ubuntu-upstart:trusty ansible_user=root
 
 In this example we define a host with name ``web`` that runs the
 `official Docker Ubuntu image`_ ``ubuntu-upstart:trusty``.
@@ -93,8 +92,7 @@ requirements:
 
 .. code-block:: yaml
 
-   # tests/test_nginx_install.yml
-   ---
+   ## tests/test_nginx_install.yml
    - include: ../nginx_install.yml
 
    - hosts: web

--- a/tests/test_docker_support_integration.py
+++ b/tests/test_docker_support_integration.py
@@ -115,7 +115,7 @@ def test_docker_pull_called_when_image_does_not_exist(testdir, docker_client):
 
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname
@@ -141,8 +141,8 @@ def test_docker_pull_is_called_once_per_image_when_multiple_times(testdir, docke
 
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname1 goodplay_image=busybox:latest
-    guesthostname2 goodplay_image=busybox:latest
+    guesthostname1 goodplay_image=busybox:latest ansible_user=root
+    guesthostname2 goodplay_image=busybox:latest ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname1:guesthostname2
@@ -168,7 +168,7 @@ def test_docker_pull_not_called_when_image_already_exists(testdir, docker_client
 
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname
@@ -223,7 +223,7 @@ def test_docker_pull_called_with_resolved_goodplay_platform(testdir, docker_clie
         image: busybox:latest
 
     ## inventory
-    guesthostname goodplay_platform=thename:theversion
+    guesthostname goodplay_platform=thename:theversion ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname
@@ -245,7 +245,7 @@ def test_docker_pull_called_with_resolved_goodplay_platform(testdir, docker_clie
 def test_started_docker_container_is_removed_after_successful_run(testdir, docker_client):
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname
@@ -270,7 +270,7 @@ def test_started_docker_container_is_removed_after_successful_run(testdir, docke
 def test_started_docker_container_is_removed_after_failed_run(testdir, docker_client):
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## test_playbook.yml
     - hosts: guesthostname
@@ -295,7 +295,7 @@ def test_started_docker_container_is_removed_after_failed_run(testdir, docker_cl
 def test_group_vars_directory_beside_inventory_file_is_incorporated(testdir):
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## group_vars/all
     hello: world
@@ -319,7 +319,7 @@ def test_group_vars_directory_beside_inventory_file_is_incorporated(testdir):
 def test_group_vars_directory_beside_inventory_directory_is_incorporated(testdir):
     smart_create(testdir.tmpdir, '''
     ## inventory/static
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## inventory/group_vars/all
     hello: world
@@ -343,7 +343,7 @@ def test_group_vars_directory_beside_inventory_directory_is_incorporated(testdir
 def test_host_vars_directory_beside_inventory_file_is_incorporated(testdir):
     smart_create(testdir.tmpdir, '''
     ## inventory
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## host_vars/guesthostname
     hello: world
@@ -367,7 +367,7 @@ def test_host_vars_directory_beside_inventory_file_is_incorporated(testdir):
 def test_host_vars_directory_beside_inventory_directory_is_incorporated(testdir):
     smart_create(testdir.tmpdir, '''
     ## inventory/static
-    guesthostname goodplay_image=busybox:latest
+    guesthostname goodplay_image=busybox:latest ansible_user=root
 
     ## inventory/host_vars/guesthostname
     hello: world
@@ -414,7 +414,7 @@ def test_role_with_goodplay_platform_wildcard(testdir, docker_client):
         image: centos:centos7
 
     ## local-role-base/role1/tests/inventory
-    default goodplay_platform=*
+    default goodplay_platform=* ansible_user=root
 
     ## local-role-base/role1/tests/test_playbook.yml
     - hosts: default


### PR DESCRIPTION
Since Ansible 2.0 there is no default remote user defined anymore (prior to that it was the current user). Up to now this didn't occur as a problem as the ``ansible_user`` wasn't used with the docker connection plugin. But this behavior has been changed in recent ansible commit ``14dfad7``.

The goodplay documentation has been also updated to reflect the change.