### PR TITLE
fix junitxml with pytest>=2.9.1

### DIFF
--- a/goodplay/junitxml.py
+++ b/goodplay/junitxml.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 import _pytest.junitxml
 
 
-def patch_mangle_testnames():
-    # monkeypatch mangle_testnames to remove .yml extension from playbook "class"
-    mangle_testnames_orig = _pytest.junitxml.mangle_testnames
+def patch_pytest_to_strip_file_extensions():
+    if hasattr(_pytest.junitxml, '_py_ext_re'):
+        # pytest>=2.9.1
+        _pytest.junitxml._py_ext_re = re.compile(r'\.(?:py|yml)$')
+    else:
+        # pytest<=2.9.0
+        # monkeypatch mangle_testnames to remove .yml extension from playbook "class"
+        mangle_testnames_orig = _pytest.junitxml.mangle_testnames
 
-    def mangle_testnames_patch(names):
-        names = mangle_testnames_orig(names)
-        return [x[:-4] if x.endswith('.yml') else x for x in names[:-1]] + [names[-1]]
-    _pytest.junitxml.mangle_testnames = mangle_testnames_patch
+        def mangle_testnames_patch(names):
+            names = mangle_testnames_orig(names)
+            return [x[:-4] if x.endswith('.yml') else x for x in names[:-1]] + [names[-1]]
+        _pytest.junitxml.mangle_testnames = mangle_testnames_patch

--- a/goodplay/junitxml.py
+++ b/goodplay/junitxml.py
@@ -9,7 +9,7 @@ def patch_pytest_to_strip_file_extensions():
     if hasattr(_pytest.junitxml, '_py_ext_re'):
         # pytest>=2.9.1
         _pytest.junitxml._py_ext_re = re.compile(r'\.(?:py|yml)$')
-    else:
+    else:  # pragma: no cover
         # pytest<=2.9.0
         # monkeypatch mangle_testnames to remove .yml extension from playbook "class"
         mangle_testnames_orig = _pytest.junitxml.mangle_testnames

--- a/goodplay/plugin.py
+++ b/goodplay/plugin.py
@@ -9,7 +9,7 @@ import pytest
 from goodplay import ansible_support, docker_support, junitxml
 from goodplay.context import GoodplayContext
 
-junitxml.patch_mangle_testnames()
+junitxml.patch_pytest_to_strip_file_extensions()
 
 
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning


### PR DESCRIPTION
The name and arguments of the function we were monkeypatching to strip playbook file extensions has been changed in pytest==2.9.1.