### PR TITLE
test-run more Docker versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,17 @@ services:
   - docker
 
 env:
-  global:
-    - DOCKER_VERSION=1.10.0-0~trusty
   matrix:
-    - TOXENV=py27-ansible21
-    - TOXENV=py27-ansibledevel
-    - TOXENV=docs
+    - TOXENV=py27-ansible21 DOCKER_VERSION=1.10.3-0~trusty
+    - TOXENV=py27-ansible21 DOCKER_VERSION=1.11.2-0~trusty
+    - TOXENV=py27-ansibledevel DOCKER_VERSION=1.10.3-0~trusty
+    - TOXENV=py27-ansibledevel DOCKER_VERSION=1.11.2-0~trusty
+    - TOXENV=docs DOCKER_VERSION=1.11.2-0~trusty
 
 matrix:
   allow_failures:
-    - env: TOXENV=py27-ansibledevel
+    - env: TOXENV=py27-ansibledevel DOCKER_VERSION=1.10.3-0~trusty
+    - env: TOXENV=py27-ansibledevel DOCKER_VERSION=1.11.2-0~trusty
 
 before_install:
   # ensure apt-get cache is up-to-date

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,8 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 * skip Docker-related tests when Docker is not available
+* run Travis CI tests against latest two Docker minor versions,
+  each with latest patch version
 
 
 0.6.0 (2016-04-28)


### PR DESCRIPTION
run Travis CI tests against latest two Docker minor versions, each with latest patch version