### PR TITLE
fix successful wait_for test task

### DIFF
--- a/goodplay/ansible_support/callback_plugin/goodplay.py
+++ b/goodplay/ansible_support/callback_plugin/goodplay.py
@@ -51,7 +51,8 @@ def goodplay_set_task_and_variable_override(self, task, *args, **kwargs):
             # failing wait_for should not stop test execution, but should
             # pop up as test task fail due to change
             task.register = '_goodplay_wait_for_result'
-            task.changed_when = '{{ _goodplay_wait_for_result.failed | default(_goodplay_wait_for_result.changed) }}'
+            task.changed_when = \
+                '{{ _goodplay_wait_for_result.failed|default(_goodplay_wait_for_result.changed) }}'
             task.failed_when = False
 
     return new_info

--- a/goodplay/ansible_support/callback_plugin/goodplay.py
+++ b/goodplay/ansible_support/callback_plugin/goodplay.py
@@ -51,7 +51,7 @@ def goodplay_set_task_and_variable_override(self, task, *args, **kwargs):
             # failing wait_for should not stop test execution, but should
             # pop up as test task fail due to change
             task.register = '_goodplay_wait_for_result'
-            task.changed_when = '{{ _goodplay_wait_for_result.failed }}'
+            task.changed_when = '{{ _goodplay_wait_for_result.failed | default(_goodplay_wait_for_result.changed) }}'
             task.failed_when = False
 
     return new_info

--- a/tests/test_ansible_runner_integration.py
+++ b/tests/test_ansible_runner_integration.py
@@ -342,6 +342,35 @@ def test_failed_on_failed_task(testdir):
     result.assertoutcome(failed=1)
 
 
+def test_passed_on_wait_for_success(testdir):
+    smart_create(testdir.tmpdir, '''
+    ## inventory
+    127.0.0.1 ansible_connection=local
+
+    ## test_playbook.yml
+    - hosts: 127.0.0.1
+      gather_facts: no
+      tasks:
+        - name: create .pid file
+          file:
+            path: "{{ playbook_dir }}/.pid"
+            state: touch
+
+        - name: task1
+          wait_for:
+            path: "{{ playbook_dir }}/.pid"
+            timeout: 5
+          tags: test
+
+        - name: task2
+          ping:
+          tags: test
+    ''')
+
+    result = testdir.inline_run('-s')
+    result.assertoutcome(passed=2)
+
+
 def test_failed_on_wait_for_timeout(testdir):
     smart_create(testdir.tmpdir, '''
     ## inventory


### PR DESCRIPTION
A successful wait_for test task does not have the failed key in its result dictionary and thus would make the failed_when condition error.