### PR TITLE
fix to support docker>=2.0 breaking change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
     - TOXENV=py35-ansibledevel
     - TOXENV=docs
 
+matrix:
+  allow_failures:
+    - env: TOXENV=py27-ansibledevel
+    - env: TOXENV=py35-ansibledevel
+
 before_install:
   # ensure apt-get cache is up-to-date
   - sudo apt-get -qq update

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible==2.2.0.0
+ansible==2.2.1.0
 cached-property==1.3.0
-docker-compose==1.9.0
+docker-compose==1.10.0
 py==1.4.32
-pytest==3.0.5
+pytest==3.0.6
 sarge==0.1.4

--- a/tests/helpers/goodplay_helpers.py
+++ b/tests/helpers/goodplay_helpers.py
@@ -12,7 +12,7 @@ import requests
 
 
 def is_docker_available():
-    docker_client = docker.Client.from_env()
+    docker_client = docker.from_env()
 
     try:
         docker_client.version(api_version=False)


### PR DESCRIPTION
docker-compose>=1.10.0 depends on docker>=2.0.0 which brings a breaking change: docker.Client has been renamed to docker.APICLient