### PR TITLE
switch to previous Travis CI trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: deprecated-2017Q2
 
 language: python
 


### PR DESCRIPTION
Travis CI introduced new images that makes the build fail.
https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch

Until we figure out how to get this updated in the long run we temporary switch back to the previously used image.