### PR TITLE
fix get_container_name method call

### DIFF
--- a/goodplay/docker_support/__init__.py
+++ b/goodplay/docker_support/__init__.py
@@ -115,11 +115,12 @@ class DockerRunner(object):
 
         inventory_lines = []
         for service in self.project.services:
+            container_name = service.get_container_name(service.name, 1)
             inventory_line = ' '.join((
                 service.name,
                 'ansible_connection="goodplaydocker"',
                 'ansible_become_method="dockerexec"',
-                'ansible_host="{}"'.format(service.get_container_name(1)),
+                'ansible_host="{}"'.format(container_name),
             ))
             inventory_lines.append(inventory_line)
         inventory_content = '\n'.join(inventory_lines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==2.4.2.0
 cached-property==1.3.1
-docker-compose==1.17.1
+docker-compose==1.18.0
 py==1.5.2
 pytest==3.3.1
 sarge==0.1.4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 install_requires = [
     'ansible>=2.2',
     'cached-property>=1.3.1',
-    'docker-compose>=1.16.1',
+    'docker-compose>=1.18.0',
     'py>=1.4.34',
     'pytest>=3.1.2',
     'sarge>=0.1.4',


### PR DESCRIPTION
With docker-compose 1.18.0 the signature of the get_container_name method of a Service has been changed.
To avoid supporting multiple method signature versions we now require docker-compose>=1.18.0.