### PR TITLE
fix dependencies

### DIFF
--- a/goodplay/ansible_support/runner.py
+++ b/goodplay/ansible_support/runner.py
@@ -39,7 +39,7 @@ class PlaybookRunner(object):
         self.process = run(
             'ansible-playbook -vvv -i {0} {1}',
             self.ctx.extended_inventory_path, self.ctx.playbook_path,
-            env=env, async=True)
+            env=env, async_=True)
 
         # wait for subprocess to be responsive
         self.process.wait_events()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible==2.5.4
-cached-property==1.4.2
+ansible==2.5.5
+cached-property==1.4.3
 docker-compose==1.21.2
 py==1.5.3
-pytest==3.6.0
-sarge==0.1.4
+pytest==3.6.1
+sarge==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ install_requires = [
     'ansible>=2.3',
     'cached-property>=1.3.1',
     'docker-compose>=1.18.0',
+    'idna==2.6',  # pin temporary due to dep docker-py -> requests -> idna<2.7
     'py>=1.4.34',
     'pytest>=3.5.0',
-    'sarge>=0.1.4',
+    'sarge==0.1.5',
 ]
 
 readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')


### PR DESCRIPTION
Fix broken build by pinning and updating dependencies.
This supersedes and closes #158, closes #159, closes #160, and closes #162.