### PR TITLE
fix docker-compose integration

### DIFF
--- a/goodplay/docker_support/__init__.py
+++ b/goodplay/docker_support/__init__.py
@@ -125,7 +125,7 @@ class DockerRunner(object):
 
         inventory_lines = []
         for service in self.project.services:
-            container_name = service.get_container_name(service.name, 1)
+            container_name = service.get_container().name
             inventory_line = ' '.join((
                 service.name,
                 'ansible_connection="goodplaydocker"',


### PR DESCRIPTION
Docker compose v1.23.0 introduced a new method signature for service.get_container_name(...). This bugfix fixes it in a backwards-compatible manner.